### PR TITLE
Aanwezigheid `multiple` attribuut is niet meer nodig om aan te geven dat de component een multiselect is

### DIFF
--- a/demo/vl-multiselect.html
+++ b/demo/vl-multiselect.html
@@ -1,196 +1,292 @@
 <!DOCTYPE html>
 <html lang="nl">
-
-<head>
+  <head>
     <title>vl-multiselect voorbeeld</title>
-    <script type="module" src="/node_modules/vl-ui-demo/dist/vl-demo-all.js"></script>
-    <script type="module" src="/node_modules/vl-ui-body/dist/vl-body.js"></script>
-    <script type="module" src="/node_modules/vl-ui-form-grid/dist/vl-form-grid.js"></script>
-    <script type="module" src="/node_modules/vl-ui-action-group/dist/vl-action-group.js"></script>
-    <script type="module" src="/node_modules/vl-ui-button/dist/vl-button.js"></script>
-    <script type="module" src="/node_modules/vl-ui-datepicker/dist/vl-datepicker.js"></script>
+    <script
+      type="module"
+      src="/node_modules/vl-ui-demo/dist/vl-demo-all.js"
+    ></script>
+    <script
+      type="module"
+      src="/node_modules/vl-ui-body/dist/vl-body.js"
+    ></script>
+    <script
+      type="module"
+      src="/node_modules/vl-ui-form-grid/dist/vl-form-grid.js"
+    ></script>
+    <script
+      type="module"
+      src="/node_modules/vl-ui-action-group/dist/vl-action-group.js"
+    ></script>
+    <script
+      type="module"
+      src="/node_modules/vl-ui-button/dist/vl-button.js"
+    ></script>
+    <script
+      type="module"
+      src="/node_modules/vl-ui-datepicker/dist/vl-datepicker.js"
+    ></script>
 
     <script type="module" src="/src/vl-multiselect.js"></script>
 
-    <link rel="stylesheet" type="text/css" href="/src/style.css">
-    <link rel="stylesheet" type="text/css" href="/node_modules/vl-ui-body/dist/style.css">
-    <link rel="stylesheet" type="text/css" href="/node_modules/vl-ui-demo/dist/style.css">
-    <link rel="stylesheet" type="text/css" href="/node_modules/vl-ui-form-grid/dist/style.css">
-    <link rel="stylesheet" type="text/css" href="/node_modules/vl-ui-action-group/dist/style.css">
-    <link rel="stylesheet" type="text/css" href="/node_modules/vl-ui-button/dist/style.css">
-</head>
+    <link rel="stylesheet" type="text/css" href="/src/style.css" />
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="/node_modules/vl-ui-body/dist/style.css"
+    />
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="/node_modules/vl-ui-demo/dist/style.css"
+    />
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="/node_modules/vl-ui-form-grid/dist/style.css"
+    />
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="/node_modules/vl-ui-action-group/dist/style.css"
+    />
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="/node_modules/vl-ui-button/dist/style.css"
+    />
+  </head>
 
-<body is="vl-body">
-    <vl-demo-page data-vl-webcomponent="vl-multiselect" data-vl-link="https://overheid.vlaanderen.be/webuniversum/v3/documentation/forms/vl-ui-multiselect">
-        <vl-demo data-vl-title="Multiselect met meerdere opties">
-            <select id="multiselect" is="vl-multiselect" multiple>
-                <option value="Belgium">België</option>
-                <option value="Germany">Duitsland</option>
-                <option value="France">Frankrijk</option>
+  <body is="vl-body">
+    <vl-demo-page
+      data-vl-webcomponent="vl-multiselect"
+      data-vl-link="https://overheid.vlaanderen.be/webuniversum/v3/documentation/forms/vl-ui-multiselect"
+    >
+      <vl-demo data-vl-title="Multiselect met meerdere opties">
+        <select id="multiselect" is="vl-multiselect">
+          <option value="Belgium">België</option>
+          <option value="Germany">Duitsland</option>
+          <option value="France">Frankrijk</option>
+        </select>
+      </vl-demo>
+
+      <vl-demo data-vl-title="Multiselect met een voorgeselecteerde optie">
+        <select id="multiselect-voorgeselecteerd" is="vl-multiselect">
+          <option selected value="Bruges">Brugge</option>
+          <option value="Brussels">Brussel</option>
+          <option value="Ghent">Gent</option>
+        </select>
+      </vl-demo>
+
+      <vl-demo data-vl-title="Multiselect met gegroepeerde opties">
+        <select id="multiselect-gegroepeerd" is="vl-multiselect">
+          <optgroup label="Landen">
+            <option selected value="Belgium">België</option>
+            <option value="Germany">Duitsland</option>
+            <option value="France">Frankrijk</option>
+          </optgroup>
+          <optgroup label="Steden">
+            <option selected value="Bruges">Brugge</option>
+            <option value="Brussels">Brussel</option>
+            <option value="Ghent">Gent</option>
+          </optgroup>
+        </select>
+      </vl-demo>
+
+      <vl-demo data-vl-title="Multiselect met error">
+        <select id="multiselect-error" is="vl-multiselect" data-vl-error>
+          <option value="Belgium">België</option>
+          <option value="Germany">Duitsland</option>
+          <option value="France">Frankrijk</option>
+        </select>
+      </vl-demo>
+
+      <vl-demo data-vl-title="Multiselect met success">
+        <select id="multiselect-success" is="vl-multiselect" data-vl-success>
+          <option value="Belgium">België</option>
+          <option value="Germany">Duitsland</option>
+          <option value="France">Frankrijk</option>
+        </select>
+      </vl-demo>
+
+      <vl-demo data-vl-title="Multiselect met disabled">
+        <select id="multiselect-disabled" is="vl-multiselect" disabled>
+          <option value="Belgium">België</option>
+          <option value="Germany">Duitsland</option>
+          <option value="France">Frankrijk</option>
+        </select>
+      </vl-demo>
+
+      <vl-demo
+        data-vl-title="Select van straten met specifiek aantal resultaten"
+      >
+        <select
+          id="multiselect-specifiek"
+          is="vl-multiselect"
+          data-vl-select
+          data-vl-select-search-result-limit="5"
+        >
+          <option placeholder value="">Kies een straat</option>
+          <option value="aakstraat">Aakstraat</option>
+          <option value="aalmoezenierstraat">Aalmoezenierstraat</option>
+          <option value="aarschotstraat">Aarschotstraat</option>
+          <option value="aartselaarstraat">Aartselaarstraat</option>
+          <option value="abdijstraat">Abdijstraat</option>
+          <option value="abtenstraat">Abtenstraat</option>
+          <option value="achturendagstraat">Achturendagstraat</option>
+          <option value="adelaarstraat">Adelaarstraat</option>
+          <option value="admiraal de Boisotstraat">
+            Admiraal de Boisotstraat
+          </option>
+          <option value="adolf Greinerstraat">Adolf Greinerstraat</option>
+          <option value="adolf Menystraat">Adolf Menystraat</option>
+          <option value="adolf Meurissestraat">Adolf Meurissestraat</option>
+          <option value="adriaan Brouwerstraat">Adriaan Brouwerstraat</option>
+          <option value="aimé De Graevestraat">Aimé De Graevestraat</option>
+        </select>
+      </vl-demo>
+
+      <vl-demo
+        data-vl-title="Select van straten met een onbeperkt aantal resultaten"
+      >
+        <select
+          id="multiselect-onbeperkt"
+          is="vl-multiselect"
+          data-vl-select
+          data-vl-select-search-no-result-limit
+        >
+          <option placeholder value="">Kies een straat</option>
+          <option value="aakstraat">Aakstraat</option>
+          <option value="aalmoezenierstraat">Aalmoezenierstraat</option>
+          <option value="aarschotstraat">Aarschotstraat</option>
+          <option value="aartselaarstraat">Aartselaarstraat</option>
+          <option value="abdijstraat">Abdijstraat</option>
+          <option value="abtenstraat">Abtenstraat</option>
+          <option value="achturendagstraat">Achturendagstraat</option>
+          <option value="adelaarstraat">Adelaarstraat</option>
+          <option value="admiraal de Boisotstraat">
+            Admiraal de Boisotstraat
+          </option>
+          <option value="adolf Greinerstraat">Adolf Greinerstraat</option>
+          <option value="adolf Menystraat">Adolf Menystraat</option>
+          <option value="adolf Meurissestraat">Adolf Meurissestraat</option>
+          <option value="adriaan Brouwerstraat">Adriaan Brouwerstraat</option>
+          <option value="aimé De Graevestraat">Aimé De Graevestraat</option>
+        </select>
+      </vl-demo>
+
+      <vl-demo data-vl-title="Multiselect boven een datepicker">
+        <div is="vl-form-grid" data-vl-is-stacked>
+          <div is="vl-form-column" data-vl-size="12">
+            <select id="multiselect-datepicker" is="vl-multiselect">
+              <option value="Belgium">België</option>
+              <option value="Germany">Duitsland</option>
+              <option value="France">Frankrijk</option>
             </select>
-        </vl-demo>
+          </div>
+          <div is="vl-form-column" data-vl-size="12">
+            <vl-datepicker id="datepicker"></vl-datepicker>
+          </div>
+        </div>
+      </vl-demo>
 
-        <vl-demo data-vl-title="Multiselect met een voorgeselecteerde optie">
-            <select id="multiselect-voorgeselecteerd" is="vl-multiselect" multiple>
-                <option selected value="Bruges">Brugge</option>
-                <option value="Brussels">Brussel</option>
-                <option value="Ghent">Gent</option>
-            </select>
-        </vl-demo>
+      <vl-demo data-vl-title="Multiselect luister naar change events">
+        <select id="change-listener" is="vl-multiselect">
+          <option value="Belgium">België</option>
+          <option value="Germany">Duitsland</option>
+          <option value="France">Frankrijk</option>
+        </select>
+        <script type="text/javascript">
+          document
+            .getElementById("change-listener")
+            .addEventListener("change", (e) => {
+              document
+                .getElementById("change-listener")
+                .setAttribute("changed", "");
+            });
+        </script>
+      </vl-demo>
 
-        <vl-demo data-vl-title="Multiselect met gegroepeerde opties">
-            <select id="multiselect-gegroepeerd" is="vl-multiselect" multiple>
-                <optgroup label="Landen">
-                    <option selected value="Belgium">België</option>
-                    <option value="Germany">Duitsland</option>
-                    <option value="France">Frankrijk</option>
-                </optgroup>
-                <optgroup label="Steden">
-                    <option selected value="Bruges">Brugge</option>
-                    <option value="Brussels">Brussel</option>
-                    <option value="Ghent">Gent</option>
-                </optgroup>
-            </select>
-        </vl-demo>
+      <vl-demo data-vl-title="Multiselect enable en disable methode">
+        <select id="vl-multiselect-enable-disable-methode" is="vl-multiselect">
+          <option value="Belgium">België</option>
+          <option value="Germany">Duitsland</option>
+          <option value="France">Frankrijk</option>
+          <option value="Netherlands">Nederland</option>
+          <option value="Italy">Italië</option>
+        </select>
 
-        <vl-demo data-vl-title="Multiselect met error">
-            <select id="multiselect-error" is="vl-multiselect" multiple data-vl-error>
-                <option value="Belgium">België</option>
-                <option value="Germany">Duitsland</option>
-                <option value="France">Frankrijk</option>
-            </select>
-        </vl-demo>
+        <div is="vl-action-group" slot="actions">
+          <button
+            id="enable"
+            is="vl-button"
+            onclick="document.getElementById('vl-multiselect-enable-disable-methode').enable()"
+            type="button"
+          >
+            Enable
+          </button>
+          <button
+            id="disable"
+            is="vl-button"
+            onclick="document.getElementById('vl-multiselect-enable-disable-methode').disable()"
+            type="button"
+          >
+            Disable
+          </button>
+        </div>
+      </vl-demo>
 
-        <vl-demo data-vl-title="Multiselect met success">
-            <select id="multiselect-success" is="vl-multiselect" multiple data-vl-success>
-                <option value="Belgium">België</option>
-                <option value="Germany">Duitsland</option>
-                <option value="France">Frankrijk</option>
-            </select>
-        </vl-demo>
+      <vl-demo data-vl-title="Multiselect zet en verwijder keuze methoden">
+        <select id="vl-multiselect-set-get-methode" is="vl-multiselect">
+          <option value="Belgium">België</option>
+          <option value="Germany">Duitsland</option>
+          <option value="France">Frankrijk</option>
+          <option value="Netherlands">Nederland</option>
+          <option value="Italy">Italië</option>
+        </select>
 
-        <vl-demo data-vl-title="Multiselect met disabled">
-            <select id="multiselect-disabled" is="vl-multiselect" multiple disabled>
-                <option value="Belgium">België</option>
-                <option value="Germany">Duitsland</option>
-                <option value="France">Frankrijk</option>
-            </select>
-        </vl-demo>
+        <div is="vl-action-group" slot="actions">
+          <button
+            id="duitsland"
+            is="vl-button"
+            onclick="document.getElementById('vl-multiselect-set-get-methode').value = 'Germany'"
+            type="button"
+          >
+            Kies Duitsland
+          </button>
+          <button
+            id="be-nl"
+            is="vl-button"
+            onclick="document.getElementById('vl-multiselect-set-get-methode').values = ['Belgium', 'Netherlands']"
+            type="button"
+          >
+            Kies België en Nederland
+          </button>
+          <button
+            id="verwijder"
+            is="vl-button"
+            onclick="document.getElementById('vl-multiselect-set-get-methode').removeActive()"
+            type="button"
+          >
+            Verwijder selectie
+          </button>
+        </div>
+      </vl-demo>
 
-        <vl-demo data-vl-title="Select van straten met specifiek aantal resultaten">
-            <select id="multiselect-specifiek" is="vl-multiselect" data-vl-select data-vl-select-search-result-limit="5" multiple>
-                <option placeholder value="">Kies een straat</option>
-                <option value="aakstraat">Aakstraat</option>
-                <option value="aalmoezenierstraat">Aalmoezenierstraat</option>
-                <option value="aarschotstraat">Aarschotstraat</option>
-                <option value="aartselaarstraat">Aartselaarstraat</option>
-                <option value="abdijstraat">Abdijstraat</option>
-                <option value="abtenstraat">Abtenstraat</option>
-                <option value="achturendagstraat">Achturendagstraat</option>
-                <option value="adelaarstraat">Adelaarstraat</option>
-                <option value="admiraal de Boisotstraat">Admiraal de Boisotstraat</option>
-                <option value="adolf Greinerstraat">Adolf Greinerstraat</option>
-                <option value="adolf Menystraat">Adolf Menystraat</option>
-                <option value="adolf Meurissestraat">Adolf Meurissestraat</option>
-                <option value="adriaan Brouwerstraat">Adriaan Brouwerstraat</option>
-                <option value="aimé De Graevestraat">Aimé De Graevestraat</option>
-            </select>
-        </vl-demo>
-
-        <vl-demo data-vl-title="Select van straten met een onbeperkt aantal resultaten">
-            <select id="multiselect-onbeperkt" is="vl-multiselect" data-vl-select data-vl-select-search-no-result-limit multiple>
-                <option placeholder value="">Kies een straat</option>
-                <option value="aakstraat">Aakstraat</option>
-                <option value="aalmoezenierstraat">Aalmoezenierstraat</option>
-                <option value="aarschotstraat">Aarschotstraat</option>
-                <option value="aartselaarstraat">Aartselaarstraat</option>
-                <option value="abdijstraat">Abdijstraat</option>
-                <option value="abtenstraat">Abtenstraat</option>
-                <option value="achturendagstraat">Achturendagstraat</option>
-                <option value="adelaarstraat">Adelaarstraat</option>
-                <option value="admiraal de Boisotstraat">Admiraal de Boisotstraat</option>
-                <option value="adolf Greinerstraat">Adolf Greinerstraat</option>
-                <option value="adolf Menystraat">Adolf Menystraat</option>
-                <option value="adolf Meurissestraat">Adolf Meurissestraat</option>
-                <option value="adriaan Brouwerstraat">Adriaan Brouwerstraat</option>
-                <option value="aimé De Graevestraat">Aimé De Graevestraat</option>
-            </select>
-        </vl-demo>
-
-        <vl-demo data-vl-title="Multiselect boven een datepicker">
-            <div is="vl-form-grid" data-vl-is-stacked>
-                <div is="vl-form-column" data-vl-size="12">
-                    <select id="multiselect-datepicker" is="vl-multiselect" multiple>
-                        <option value="Belgium">België</option>
-                        <option value="Germany">Duitsland</option>
-                        <option value="France">Frankrijk</option>
-                    </select>
-                </div>
-                <div is="vl-form-column" data-vl-size="12">
-                    <vl-datepicker id="datepicker"></vl-datepicker>
-                </div>
-            </div>
-        </vl-demo>
-
-        <vl-demo data-vl-title="Multiselect luister naar change events">
-            <select id="change-listener" is="vl-multiselect" multiple>
-                <option value="Belgium">België</option>
-                <option value="Germany">Duitsland</option>
-                <option value="France">Frankrijk</option>
-            </select>
-            <script type="text/javascript">
-                document.getElementById('change-listener').addEventListener('change', (e) => {
-                  document.getElementById('change-listener').setAttribute('changed', '');
-                });
-            </script>
-        </vl-demo>
-
-        <vl-demo data-vl-title="Multiselect enable en disable methode">
-            <select id="vl-multiselect-enable-disable-methode" is="vl-multiselect" multiple>
-                <option value="Belgium">België</option>
-                <option value="Germany">Duitsland</option>
-                <option value="France">Frankrijk</option>
-                <option value="Netherlands">Nederland</option>
-                <option value="Italy">Italië</option>
-            </select>
-
-            <div is="vl-action-group" slot="actions">
-                <button id="enable" is="vl-button" onclick="document.getElementById('vl-multiselect-enable-disable-methode').enable()" type="button">Enable</button>
-                <button id="disable" is="vl-button" onclick="document.getElementById('vl-multiselect-enable-disable-methode').disable()" type="button">Disable</button>
-            </div>
-        </vl-demo>
-
-        <vl-demo data-vl-title="Multiselect zet en verwijder keuze methoden">
-            <select id="vl-multiselect-set-get-methode" is="vl-multiselect" multiple>
-                <option value="Belgium">België</option>
-                <option value="Germany">Duitsland</option>
-                <option value="France">Frankrijk</option>
-                <option value="Netherlands">Nederland</option>
-                <option value="Italy">Italië</option>
-            </select>
-
-            <div is="vl-action-group" slot="actions">
-                <button id="duitsland" is="vl-button" onclick="document.getElementById('vl-multiselect-set-get-methode').value = 'Germany'" type="button">
-                    Kies Duitsland
-                </button>
-                <button id="be-nl" is="vl-button" onclick="document.getElementById('vl-multiselect-set-get-methode').values = ['Belgium', 'Netherlands']" type="button">
-                    Kies België en Nederland
-                </button>
-                <button id="verwijder" is="vl-button" onclick="document.getElementById('vl-multiselect-set-get-methode').removeActive()" type="button">
-                    Verwijder selectie
-                </button>
-            </div>
-        </vl-demo>
-
-        <vl-demo data-vl-title="Multiselect focus">
-            <select id="vl-multiselect-focus" is="vl-multiselect" multiple>
-                <option value="Belgium">België</option>
-                <option value="Germany">Duitsland</option>
-                <option value="France">Frankrijk</option>
-            </select>
-            <button is="vl-button" onclick="document.getElementById('vl-multiselect-focus').focus()" slot="actions">Focus</button>
-        </vl-demo>
+      <vl-demo data-vl-title="Multiselect focus">
+        <select id="vl-multiselect-focus" is="vl-multiselect">
+          <option value="Belgium">België</option>
+          <option value="Germany">Duitsland</option>
+          <option value="France">Frankrijk</option>
+        </select>
+        <button
+          is="vl-button"
+          onclick="document.getElementById('vl-multiselect-focus').focus()"
+          slot="actions"
+        >
+          Focus
+        </button>
+      </vl-demo>
     </vl-demo-page>
-</body>
-
+  </body>
 </html>

--- a/demo/vl-multiselect.html
+++ b/demo/vl-multiselect.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="nl">
+
 <head>
     <title>vl-multiselect voorbeeld</title>
     <script type="module" src="/node_modules/vl-ui-demo/dist/vl-demo-all.js"></script>
@@ -87,9 +88,7 @@
                 <option value="abtenstraat">Abtenstraat</option>
                 <option value="achturendagstraat">Achturendagstraat</option>
                 <option value="adelaarstraat">Adelaarstraat</option>
-                <option value="admiraal de Boisotstraat">
-                    Admiraal de Boisotstraat
-                </option>
+                <option value="admiraal de Boisotstraat">Admiraal de Boisotstraat</option>
                 <option value="adolf Greinerstraat">Adolf Greinerstraat</option>
                 <option value="adolf Menystraat">Adolf Menystraat</option>
                 <option value="adolf Meurissestraat">Adolf Meurissestraat</option>
@@ -109,9 +108,7 @@
                 <option value="abtenstraat">Abtenstraat</option>
                 <option value="achturendagstraat">Achturendagstraat</option>
                 <option value="adelaarstraat">Adelaarstraat</option>
-                <option value="admiraal de Boisotstraat">
-                    Admiraal de Boisotstraat
-                </option>
+                <option value="admiraal de Boisotstraat">Admiraal de Boisotstraat</option>
                 <option value="adolf Greinerstraat">Adolf Greinerstraat</option>
                 <option value="adolf Menystraat">Adolf Menystraat</option>
                 <option value="adolf Meurissestraat">Adolf Meurissestraat</option>

--- a/demo/vl-multiselect.html
+++ b/demo/vl-multiselect.html
@@ -1,292 +1,204 @@
 <!DOCTYPE html>
 <html lang="nl">
-  <head>
-    <title>vl-multiselect voorbeeld</title>
-    <script
-      type="module"
-      src="/node_modules/vl-ui-demo/dist/vl-demo-all.js"
-    ></script>
-    <script
-      type="module"
-      src="/node_modules/vl-ui-body/dist/vl-body.js"
-    ></script>
-    <script
-      type="module"
-      src="/node_modules/vl-ui-form-grid/dist/vl-form-grid.js"
-    ></script>
-    <script
-      type="module"
-      src="/node_modules/vl-ui-action-group/dist/vl-action-group.js"
-    ></script>
-    <script
-      type="module"
-      src="/node_modules/vl-ui-button/dist/vl-button.js"
-    ></script>
-    <script
-      type="module"
-      src="/node_modules/vl-ui-datepicker/dist/vl-datepicker.js"
-    ></script>
+<head>
+  <title>vl-multiselect voorbeeld</title>
+  <script type="module" src="/node_modules/vl-ui-demo/dist/vl-demo-all.js"></script>
+  <script type="module" src="/node_modules/vl-ui-body/dist/vl-body.js"></script>
+  <script type="module" src="/node_modules/vl-ui-form-grid/dist/vl-form-grid.js"></script>
+  <script type="module" src="/node_modules/vl-ui-action-group/dist/vl-action-group.js"></script>
+  <script type="module" src="/node_modules/vl-ui-button/dist/vl-button.js"></script>
+  <script type="module" src="/node_modules/vl-ui-datepicker/dist/vl-datepicker.js"></script>
 
-    <script type="module" src="/src/vl-multiselect.js"></script>
+  <script type="module" src="/src/vl-multiselect.js"></script>
 
-    <link rel="stylesheet" type="text/css" href="/src/style.css" />
-    <link
-      rel="stylesheet"
-      type="text/css"
-      href="/node_modules/vl-ui-body/dist/style.css"
-    />
-    <link
-      rel="stylesheet"
-      type="text/css"
-      href="/node_modules/vl-ui-demo/dist/style.css"
-    />
-    <link
-      rel="stylesheet"
-      type="text/css"
-      href="/node_modules/vl-ui-form-grid/dist/style.css"
-    />
-    <link
-      rel="stylesheet"
-      type="text/css"
-      href="/node_modules/vl-ui-action-group/dist/style.css"
-    />
-    <link
-      rel="stylesheet"
-      type="text/css"
-      href="/node_modules/vl-ui-button/dist/style.css"
-    />
-  </head>
+  <link rel="stylesheet" type="text/css" href="/src/style.css" />
+  <link rel="stylesheet" type="text/css" href="/node_modules/vl-ui-body/dist/style.css"/>
+  <link rel="stylesheet" type="text/css" href="/node_modules/vl-ui-demo/dist/style.css"/>
+  <link rel="stylesheet" type="text/css" href="/node_modules/vl-ui-form-grid/dist/style.css"/>
+  <link rel="stylesheet" type="text/css" href="/node_modules/vl-ui-action-group/dist/style.css"/>
+  <link rel="stylesheet" type="text/css" href="/node_modules/vl-ui-button/dist/style.css"/>
+</head>
 
-  <body is="vl-body">
-    <vl-demo-page
-      data-vl-webcomponent="vl-multiselect"
-      data-vl-link="https://overheid.vlaanderen.be/webuniversum/v3/documentation/forms/vl-ui-multiselect"
-    >
-      <vl-demo data-vl-title="Multiselect met meerdere opties">
-        <select id="multiselect" is="vl-multiselect">
-          <option value="Belgium">België</option>
+<body is="vl-body">
+  <vl-demo-page data-vl-webcomponent="vl-multiselect" data-vl-link="https://overheid.vlaanderen.be/webuniversum/v3/documentation/forms/vl-ui-multiselect">
+    <vl-demo data-vl-title="Multiselect met meerdere opties">
+      <select id="multiselect" is="vl-multiselect">
+        <option value="Belgium">België</option>
+        <option value="Germany">Duitsland</option>
+        <option value="France">Frankrijk</option>
+      </select>
+    </vl-demo>
+
+    <vl-demo data-vl-title="Multiselect met een voorgeselecteerde optie">
+      <select id="multiselect-voorgeselecteerd" is="vl-multiselect">
+        <option selected value="Bruges">Brugge</option>
+        <option value="Brussels">Brussel</option>
+        <option value="Ghent">Gent</option>
+      </select>
+    </vl-demo>
+
+    <vl-demo data-vl-title="Multiselect met gegroepeerde opties">
+      <select id="multiselect-gegroepeerd" is="vl-multiselect">
+        <optgroup label="Landen">
+          <option selected value="Belgium">België</option>
           <option value="Germany">Duitsland</option>
           <option value="France">Frankrijk</option>
-        </select>
-      </vl-demo>
-
-      <vl-demo data-vl-title="Multiselect met een voorgeselecteerde optie">
-        <select id="multiselect-voorgeselecteerd" is="vl-multiselect">
+        </optgroup>
+        <optgroup label="Steden">
           <option selected value="Bruges">Brugge</option>
           <option value="Brussels">Brussel</option>
           <option value="Ghent">Gent</option>
-        </select>
-      </vl-demo>
+        </optgroup>
+      </select>
+    </vl-demo>
 
-      <vl-demo data-vl-title="Multiselect met gegroepeerde opties">
-        <select id="multiselect-gegroepeerd" is="vl-multiselect">
-          <optgroup label="Landen">
-            <option selected value="Belgium">België</option>
+    <vl-demo data-vl-title="Multiselect met error">
+      <select id="multiselect-error" is="vl-multiselect" data-vl-error>
+        <option value="Belgium">België</option>
+        <option value="Germany">Duitsland</option>
+        <option value="France">Frankrijk</option>
+      </select>
+    </vl-demo>
+
+    <vl-demo data-vl-title="Multiselect met success">
+      <select id="multiselect-success" is="vl-multiselect" data-vl-success>
+        <option value="Belgium">België</option>
+        <option value="Germany">Duitsland</option>
+        <option value="France">Frankrijk</option>
+      </select>
+    </vl-demo>
+
+    <vl-demo data-vl-title="Multiselect met disabled">
+      <select id="multiselect-disabled" is="vl-multiselect" disabled>
+        <option value="Belgium">België</option>
+        <option value="Germany">Duitsland</option>
+        <option value="France">Frankrijk</option>
+      </select>
+    </vl-demo>
+
+    <vl-demo data-vl-title="Select van straten met specifiek aantal resultaten">
+      <select id="multiselect-specifiek" is="vl-multiselect" data-vl-select data-vl-select-search-result-limit="5">
+        <option placeholder value="">Kies een straat</option>
+        <option value="aakstraat">Aakstraat</option>
+        <option value="aalmoezenierstraat">Aalmoezenierstraat</option>
+        <option value="aarschotstraat">Aarschotstraat</option>
+        <option value="aartselaarstraat">Aartselaarstraat</option>
+        <option value="abdijstraat">Abdijstraat</option>
+        <option value="abtenstraat">Abtenstraat</option>
+        <option value="achturendagstraat">Achturendagstraat</option>
+        <option value="adelaarstraat">Adelaarstraat</option>
+        <option value="admiraal de Boisotstraat">
+          Admiraal de Boisotstraat
+        </option>
+        <option value="adolf Greinerstraat">Adolf Greinerstraat</option>
+        <option value="adolf Menystraat">Adolf Menystraat</option>
+        <option value="adolf Meurissestraat">Adolf Meurissestraat</option>
+        <option value="adriaan Brouwerstraat">Adriaan Brouwerstraat</option>
+        <option value="aimé De Graevestraat">Aimé De Graevestraat</option>
+      </select>
+    </vl-demo>
+
+    <vl-demo data-vl-title="Select van straten met een onbeperkt aantal resultaten">
+      <select id="multiselect-onbeperkt" is="vl-multiselect" data-vl-select data-vl-select-search-no-result-limit>
+        <option placeholder value="">Kies een straat</option>
+        <option value="aakstraat">Aakstraat</option>
+        <option value="aalmoezenierstraat">Aalmoezenierstraat</option>
+        <option value="aarschotstraat">Aarschotstraat</option>
+        <option value="aartselaarstraat">Aartselaarstraat</option>
+        <option value="abdijstraat">Abdijstraat</option>
+        <option value="abtenstraat">Abtenstraat</option>
+        <option value="achturendagstraat">Achturendagstraat</option>
+        <option value="adelaarstraat">Adelaarstraat</option>
+        <option value="admiraal de Boisotstraat">
+          Admiraal de Boisotstraat
+        </option>
+        <option value="adolf Greinerstraat">Adolf Greinerstraat</option>
+        <option value="adolf Menystraat">Adolf Menystraat</option>
+        <option value="adolf Meurissestraat">Adolf Meurissestraat</option>
+        <option value="adriaan Brouwerstraat">Adriaan Brouwerstraat</option>
+        <option value="aimé De Graevestraat">Aimé De Graevestraat</option>
+      </select>
+    </vl-demo>
+
+    <vl-demo data-vl-title="Multiselect boven een datepicker">
+      <div is="vl-form-grid" data-vl-is-stacked>
+        <div is="vl-form-column" data-vl-size="12">
+          <select id="multiselect-datepicker" is="vl-multiselect">
+            <option value="Belgium">België</option>
             <option value="Germany">Duitsland</option>
             <option value="France">Frankrijk</option>
-          </optgroup>
-          <optgroup label="Steden">
-            <option selected value="Bruges">Brugge</option>
-            <option value="Brussels">Brussel</option>
-            <option value="Ghent">Gent</option>
-          </optgroup>
-        </select>
-      </vl-demo>
-
-      <vl-demo data-vl-title="Multiselect met error">
-        <select id="multiselect-error" is="vl-multiselect" data-vl-error>
-          <option value="Belgium">België</option>
-          <option value="Germany">Duitsland</option>
-          <option value="France">Frankrijk</option>
-        </select>
-      </vl-demo>
-
-      <vl-demo data-vl-title="Multiselect met success">
-        <select id="multiselect-success" is="vl-multiselect" data-vl-success>
-          <option value="Belgium">België</option>
-          <option value="Germany">Duitsland</option>
-          <option value="France">Frankrijk</option>
-        </select>
-      </vl-demo>
-
-      <vl-demo data-vl-title="Multiselect met disabled">
-        <select id="multiselect-disabled" is="vl-multiselect" disabled>
-          <option value="Belgium">België</option>
-          <option value="Germany">Duitsland</option>
-          <option value="France">Frankrijk</option>
-        </select>
-      </vl-demo>
-
-      <vl-demo
-        data-vl-title="Select van straten met specifiek aantal resultaten"
-      >
-        <select
-          id="multiselect-specifiek"
-          is="vl-multiselect"
-          data-vl-select
-          data-vl-select-search-result-limit="5"
-        >
-          <option placeholder value="">Kies een straat</option>
-          <option value="aakstraat">Aakstraat</option>
-          <option value="aalmoezenierstraat">Aalmoezenierstraat</option>
-          <option value="aarschotstraat">Aarschotstraat</option>
-          <option value="aartselaarstraat">Aartselaarstraat</option>
-          <option value="abdijstraat">Abdijstraat</option>
-          <option value="abtenstraat">Abtenstraat</option>
-          <option value="achturendagstraat">Achturendagstraat</option>
-          <option value="adelaarstraat">Adelaarstraat</option>
-          <option value="admiraal de Boisotstraat">
-            Admiraal de Boisotstraat
-          </option>
-          <option value="adolf Greinerstraat">Adolf Greinerstraat</option>
-          <option value="adolf Menystraat">Adolf Menystraat</option>
-          <option value="adolf Meurissestraat">Adolf Meurissestraat</option>
-          <option value="adriaan Brouwerstraat">Adriaan Brouwerstraat</option>
-          <option value="aimé De Graevestraat">Aimé De Graevestraat</option>
-        </select>
-      </vl-demo>
-
-      <vl-demo
-        data-vl-title="Select van straten met een onbeperkt aantal resultaten"
-      >
-        <select
-          id="multiselect-onbeperkt"
-          is="vl-multiselect"
-          data-vl-select
-          data-vl-select-search-no-result-limit
-        >
-          <option placeholder value="">Kies een straat</option>
-          <option value="aakstraat">Aakstraat</option>
-          <option value="aalmoezenierstraat">Aalmoezenierstraat</option>
-          <option value="aarschotstraat">Aarschotstraat</option>
-          <option value="aartselaarstraat">Aartselaarstraat</option>
-          <option value="abdijstraat">Abdijstraat</option>
-          <option value="abtenstraat">Abtenstraat</option>
-          <option value="achturendagstraat">Achturendagstraat</option>
-          <option value="adelaarstraat">Adelaarstraat</option>
-          <option value="admiraal de Boisotstraat">
-            Admiraal de Boisotstraat
-          </option>
-          <option value="adolf Greinerstraat">Adolf Greinerstraat</option>
-          <option value="adolf Menystraat">Adolf Menystraat</option>
-          <option value="adolf Meurissestraat">Adolf Meurissestraat</option>
-          <option value="adriaan Brouwerstraat">Adriaan Brouwerstraat</option>
-          <option value="aimé De Graevestraat">Aimé De Graevestraat</option>
-        </select>
-      </vl-demo>
-
-      <vl-demo data-vl-title="Multiselect boven een datepicker">
-        <div is="vl-form-grid" data-vl-is-stacked>
-          <div is="vl-form-column" data-vl-size="12">
-            <select id="multiselect-datepicker" is="vl-multiselect">
-              <option value="Belgium">België</option>
-              <option value="Germany">Duitsland</option>
-              <option value="France">Frankrijk</option>
-            </select>
-          </div>
-          <div is="vl-form-column" data-vl-size="12">
-            <vl-datepicker id="datepicker"></vl-datepicker>
-          </div>
+          </select>
         </div>
-      </vl-demo>
-
-      <vl-demo data-vl-title="Multiselect luister naar change events">
-        <select id="change-listener" is="vl-multiselect">
-          <option value="Belgium">België</option>
-          <option value="Germany">Duitsland</option>
-          <option value="France">Frankrijk</option>
-        </select>
-        <script type="text/javascript">
-          document
-              .getElementById('change-listener')
-              .addEventListener('change', (e) => {
-                document
-                    .getElementById('change-listener')
-                    .setAttribute('changed', '');
-              });
-        </script>
-      </vl-demo>
-
-      <vl-demo data-vl-title="Multiselect enable en disable methode">
-        <select id="vl-multiselect-enable-disable-methode" is="vl-multiselect">
-          <option value="Belgium">België</option>
-          <option value="Germany">Duitsland</option>
-          <option value="France">Frankrijk</option>
-          <option value="Netherlands">Nederland</option>
-          <option value="Italy">Italië</option>
-        </select>
-
-        <div is="vl-action-group" slot="actions">
-          <button
-            id="enable"
-            is="vl-button"
-            onclick="document.getElementById('vl-multiselect-enable-disable-methode').enable()"
-            type="button"
-          >
-            Enable
-          </button>
-          <button
-            id="disable"
-            is="vl-button"
-            onclick="document.getElementById('vl-multiselect-enable-disable-methode').disable()"
-            type="button"
-          >
-            Disable
-          </button>
+        <div is="vl-form-column" data-vl-size="12">
+          <vl-datepicker id="datepicker"></vl-datepicker>
         </div>
-      </vl-demo>
+      </div>
+    </vl-demo>
 
-      <vl-demo data-vl-title="Multiselect zet en verwijder keuze methoden">
-        <select id="vl-multiselect-set-get-methode" is="vl-multiselect">
-          <option value="Belgium">België</option>
-          <option value="Germany">Duitsland</option>
-          <option value="France">Frankrijk</option>
-          <option value="Netherlands">Nederland</option>
-          <option value="Italy">Italië</option>
-        </select>
+    <vl-demo data-vl-title="Multiselect luister naar change events">
+      <select id="change-listener" is="vl-multiselect">
+        <option value="Belgium">België</option>
+        <option value="Germany">Duitsland</option>
+        <option value="France">Frankrijk</option>
+      </select>
+      <script type="text/javascript">
+        document.getElementById('change-listener').addEventListener('change', (e) => {
+          document.getElementById('change-listener').setAttribute('changed', '');
+        });
+      </script>
+    </vl-demo>
 
-        <div is="vl-action-group" slot="actions">
-          <button
-            id="duitsland"
-            is="vl-button"
-            onclick="document.getElementById('vl-multiselect-set-get-methode').value = 'Germany'"
-            type="button"
-          >
-            Kies Duitsland
-          </button>
-          <button
-            id="be-nl"
-            is="vl-button"
-            onclick="document.getElementById('vl-multiselect-set-get-methode').values = ['Belgium', 'Netherlands']"
-            type="button"
-          >
-            Kies België en Nederland
-          </button>
-          <button
-            id="verwijder"
-            is="vl-button"
-            onclick="document.getElementById('vl-multiselect-set-get-methode').removeActive()"
-            type="button"
-          >
-            Verwijder selectie
-          </button>
-        </div>
-      </vl-demo>
+    <vl-demo data-vl-title="Multiselect enable en disable methode">
+      <select id="vl-multiselect-enable-disable-methode" is="vl-multiselect">
+        <option value="Belgium">België</option>
+        <option value="Germany">Duitsland</option>
+        <option value="France">Frankrijk</option>
+        <option value="Netherlands">Nederland</option>
+        <option value="Italy">Italië</option>
+      </select>
 
-      <vl-demo data-vl-title="Multiselect focus">
-        <select id="vl-multiselect-focus" is="vl-multiselect">
-          <option value="Belgium">België</option>
-          <option value="Germany">Duitsland</option>
-          <option value="France">Frankrijk</option>
-        </select>
-        <button
-          is="vl-button"
-          onclick="document.getElementById('vl-multiselect-focus').focus()"
-          slot="actions"
-        >
-          Focus
+      <div is="vl-action-group" slot="actions">
+        <button id="enable" is="vl-button" onclick="document.getElementById('vl-multiselect-enable-disable-methode').enable()" type="button">
+          Enable
         </button>
-      </vl-demo>
-    </vl-demo-page>
-  </body>
+        <button id="disable" is="vl-button" onclick="document.getElementById('vl-multiselect-enable-disable-methode').disable()" type="button">
+          Disable
+        </button>
+      </div>
+    </vl-demo>
+
+    <vl-demo data-vl-title="Multiselect zet en verwijder keuze methoden">
+      <select id="vl-multiselect-set-get-methode" is="vl-multiselect">
+        <option value="Belgium">België</option>
+        <option value="Germany">Duitsland</option>
+        <option value="France">Frankrijk</option>
+        <option value="Netherlands">Nederland</option>
+        <option value="Italy">Italië</option>
+      </select>
+
+      <div is="vl-action-group" slot="actions">
+        <button id="duitsland" is="vl-button" onclick="document.getElementById('vl-multiselect-set-get-methode').value = 'Germany'" type="button">
+          Kies Duitsland
+        </button>
+        <button id="be-nl" is="vl-button" onclick="document.getElementById('vl-multiselect-set-get-methode').values = ['Belgium', 'Netherlands']" type="button">
+          Kies België en Nederland
+        </button>
+        <button id="verwijder" is="vl-button" onclick="document.getElementById('vl-multiselect-set-get-methode').removeActive()" type="button">
+          Verwijder selectie
+        </button>
+      </div>
+    </vl-demo>
+
+    <vl-demo data-vl-title="Multiselect focus">
+      <select id="vl-multiselect-focus" is="vl-multiselect">
+        <option value="Belgium">België</option>
+        <option value="Germany">Duitsland</option>
+        <option value="France">Frankrijk</option>
+      </select>
+      <button is="vl-button" onclick="document.getElementById('vl-multiselect-focus').focus()" slot="actions">
+        Focus
+      </button>
+    </vl-demo>
+  </vl-demo-page>
+</body>
 </html>

--- a/demo/vl-multiselect.html
+++ b/demo/vl-multiselect.html
@@ -1,204 +1,204 @@
 <!DOCTYPE html>
 <html lang="nl">
 <head>
-  <title>vl-multiselect voorbeeld</title>
-  <script type="module" src="/node_modules/vl-ui-demo/dist/vl-demo-all.js"></script>
-  <script type="module" src="/node_modules/vl-ui-body/dist/vl-body.js"></script>
-  <script type="module" src="/node_modules/vl-ui-form-grid/dist/vl-form-grid.js"></script>
-  <script type="module" src="/node_modules/vl-ui-action-group/dist/vl-action-group.js"></script>
-  <script type="module" src="/node_modules/vl-ui-button/dist/vl-button.js"></script>
-  <script type="module" src="/node_modules/vl-ui-datepicker/dist/vl-datepicker.js"></script>
+    <title>vl-multiselect voorbeeld</title>
+    <script type="module" src="/node_modules/vl-ui-demo/dist/vl-demo-all.js"></script>
+    <script type="module" src="/node_modules/vl-ui-body/dist/vl-body.js"></script>
+    <script type="module" src="/node_modules/vl-ui-form-grid/dist/vl-form-grid.js"></script>
+    <script type="module" src="/node_modules/vl-ui-action-group/dist/vl-action-group.js"></script>
+    <script type="module" src="/node_modules/vl-ui-button/dist/vl-button.js"></script>
+    <script type="module" src="/node_modules/vl-ui-datepicker/dist/vl-datepicker.js"></script>
 
-  <script type="module" src="/src/vl-multiselect.js"></script>
+    <script type="module" src="/src/vl-multiselect.js"></script>
 
-  <link rel="stylesheet" type="text/css" href="/src/style.css" />
-  <link rel="stylesheet" type="text/css" href="/node_modules/vl-ui-body/dist/style.css"/>
-  <link rel="stylesheet" type="text/css" href="/node_modules/vl-ui-demo/dist/style.css"/>
-  <link rel="stylesheet" type="text/css" href="/node_modules/vl-ui-form-grid/dist/style.css"/>
-  <link rel="stylesheet" type="text/css" href="/node_modules/vl-ui-action-group/dist/style.css"/>
-  <link rel="stylesheet" type="text/css" href="/node_modules/vl-ui-button/dist/style.css"/>
+    <link rel="stylesheet" type="text/css" href="/src/style.css" />
+    <link rel="stylesheet" type="text/css" href="/node_modules/vl-ui-body/dist/style.css"/>
+    <link rel="stylesheet" type="text/css" href="/node_modules/vl-ui-demo/dist/style.css"/>
+    <link rel="stylesheet" type="text/css" href="/node_modules/vl-ui-form-grid/dist/style.css"/>
+    <link rel="stylesheet" type="text/css" href="/node_modules/vl-ui-action-group/dist/style.css"/>
+    <link rel="stylesheet" type="text/css" href="/node_modules/vl-ui-button/dist/style.css"/>
 </head>
 
 <body is="vl-body">
-  <vl-demo-page data-vl-webcomponent="vl-multiselect" data-vl-link="https://overheid.vlaanderen.be/webuniversum/v3/documentation/forms/vl-ui-multiselect">
-    <vl-demo data-vl-title="Multiselect met meerdere opties">
-      <select id="multiselect" is="vl-multiselect">
-        <option value="Belgium">België</option>
-        <option value="Germany">Duitsland</option>
-        <option value="France">Frankrijk</option>
-      </select>
-    </vl-demo>
+    <vl-demo-page data-vl-webcomponent="vl-multiselect" data-vl-link="https://overheid.vlaanderen.be/webuniversum/v3/documentation/forms/vl-ui-multiselect">
+        <vl-demo data-vl-title="Multiselect met meerdere opties">
+            <select id="multiselect" is="vl-multiselect">
+                <option value="Belgium">België</option>
+                <option value="Germany">Duitsland</option>
+                <option value="France">Frankrijk</option>
+            </select>
+        </vl-demo>
 
-    <vl-demo data-vl-title="Multiselect met een voorgeselecteerde optie">
-      <select id="multiselect-voorgeselecteerd" is="vl-multiselect">
-        <option selected value="Bruges">Brugge</option>
-        <option value="Brussels">Brussel</option>
-        <option value="Ghent">Gent</option>
-      </select>
-    </vl-demo>
+        <vl-demo data-vl-title="Multiselect met een voorgeselecteerde optie">
+            <select id="multiselect-voorgeselecteerd" is="vl-multiselect">
+                <option selected value="Bruges">Brugge</option>
+                <option value="Brussels">Brussel</option>
+                <option value="Ghent">Gent</option>
+            </select>
+        </vl-demo>
 
-    <vl-demo data-vl-title="Multiselect met gegroepeerde opties">
-      <select id="multiselect-gegroepeerd" is="vl-multiselect">
-        <optgroup label="Landen">
-          <option selected value="Belgium">België</option>
-          <option value="Germany">Duitsland</option>
-          <option value="France">Frankrijk</option>
-        </optgroup>
-        <optgroup label="Steden">
-          <option selected value="Bruges">Brugge</option>
-          <option value="Brussels">Brussel</option>
-          <option value="Ghent">Gent</option>
-        </optgroup>
-      </select>
-    </vl-demo>
+        <vl-demo data-vl-title="Multiselect met gegroepeerde opties">
+            <select id="multiselect-gegroepeerd" is="vl-multiselect">
+                <optgroup label="Landen">
+                    <option selected value="Belgium">België</option>
+                    <option value="Germany">Duitsland</option>
+                    <option value="France">Frankrijk</option>
+                </optgroup>
+                <optgroup label="Steden">
+                    <option selected value="Bruges">Brugge</option>
+                    <option value="Brussels">Brussel</option>
+                    <option value="Ghent">Gent</option>
+                </optgroup>
+            </select>
+        </vl-demo>
 
-    <vl-demo data-vl-title="Multiselect met error">
-      <select id="multiselect-error" is="vl-multiselect" data-vl-error>
-        <option value="Belgium">België</option>
-        <option value="Germany">Duitsland</option>
-        <option value="France">Frankrijk</option>
-      </select>
-    </vl-demo>
+        <vl-demo data-vl-title="Multiselect met error">
+            <select id="multiselect-error" is="vl-multiselect" data-vl-error>
+                <option value="Belgium">België</option>
+                <option value="Germany">Duitsland</option>
+                <option value="France">Frankrijk</option>
+            </select>
+        </vl-demo>
 
-    <vl-demo data-vl-title="Multiselect met success">
-      <select id="multiselect-success" is="vl-multiselect" data-vl-success>
-        <option value="Belgium">België</option>
-        <option value="Germany">Duitsland</option>
-        <option value="France">Frankrijk</option>
-      </select>
-    </vl-demo>
+        <vl-demo data-vl-title="Multiselect met success">
+            <select id="multiselect-success" is="vl-multiselect" data-vl-success>
+                <option value="Belgium">België</option>
+                <option value="Germany">Duitsland</option>
+                <option value="France">Frankrijk</option>
+            </select>
+        </vl-demo>
 
-    <vl-demo data-vl-title="Multiselect met disabled">
-      <select id="multiselect-disabled" is="vl-multiselect" disabled>
-        <option value="Belgium">België</option>
-        <option value="Germany">Duitsland</option>
-        <option value="France">Frankrijk</option>
-      </select>
-    </vl-demo>
+        <vl-demo data-vl-title="Multiselect met disabled">
+            <select id="multiselect-disabled" is="vl-multiselect" disabled>
+                <option value="Belgium">België</option>
+                <option value="Germany">Duitsland</option>
+                <option value="France">Frankrijk</option>
+            </select>
+        </vl-demo>
 
-    <vl-demo data-vl-title="Select van straten met specifiek aantal resultaten">
-      <select id="multiselect-specifiek" is="vl-multiselect" data-vl-select data-vl-select-search-result-limit="5">
-        <option placeholder value="">Kies een straat</option>
-        <option value="aakstraat">Aakstraat</option>
-        <option value="aalmoezenierstraat">Aalmoezenierstraat</option>
-        <option value="aarschotstraat">Aarschotstraat</option>
-        <option value="aartselaarstraat">Aartselaarstraat</option>
-        <option value="abdijstraat">Abdijstraat</option>
-        <option value="abtenstraat">Abtenstraat</option>
-        <option value="achturendagstraat">Achturendagstraat</option>
-        <option value="adelaarstraat">Adelaarstraat</option>
-        <option value="admiraal de Boisotstraat">
-          Admiraal de Boisotstraat
-        </option>
-        <option value="adolf Greinerstraat">Adolf Greinerstraat</option>
-        <option value="adolf Menystraat">Adolf Menystraat</option>
-        <option value="adolf Meurissestraat">Adolf Meurissestraat</option>
-        <option value="adriaan Brouwerstraat">Adriaan Brouwerstraat</option>
-        <option value="aimé De Graevestraat">Aimé De Graevestraat</option>
-      </select>
-    </vl-demo>
+        <vl-demo data-vl-title="Select van straten met specifiek aantal resultaten">
+            <select id="multiselect-specifiek" is="vl-multiselect" data-vl-select data-vl-select-search-result-limit="5">
+                <option placeholder value="">Kies een straat</option>
+                <option value="aakstraat">Aakstraat</option>
+                <option value="aalmoezenierstraat">Aalmoezenierstraat</option>
+                <option value="aarschotstraat">Aarschotstraat</option>
+                <option value="aartselaarstraat">Aartselaarstraat</option>
+                <option value="abdijstraat">Abdijstraat</option>
+                <option value="abtenstraat">Abtenstraat</option>
+                <option value="achturendagstraat">Achturendagstraat</option>
+                <option value="adelaarstraat">Adelaarstraat</option>
+                <option value="admiraal de Boisotstraat">
+                    Admiraal de Boisotstraat
+                </option>
+                <option value="adolf Greinerstraat">Adolf Greinerstraat</option>
+                <option value="adolf Menystraat">Adolf Menystraat</option>
+                <option value="adolf Meurissestraat">Adolf Meurissestraat</option>
+                <option value="adriaan Brouwerstraat">Adriaan Brouwerstraat</option>
+                <option value="aimé De Graevestraat">Aimé De Graevestraat</option>
+            </select>
+        </vl-demo>
 
-    <vl-demo data-vl-title="Select van straten met een onbeperkt aantal resultaten">
-      <select id="multiselect-onbeperkt" is="vl-multiselect" data-vl-select data-vl-select-search-no-result-limit>
-        <option placeholder value="">Kies een straat</option>
-        <option value="aakstraat">Aakstraat</option>
-        <option value="aalmoezenierstraat">Aalmoezenierstraat</option>
-        <option value="aarschotstraat">Aarschotstraat</option>
-        <option value="aartselaarstraat">Aartselaarstraat</option>
-        <option value="abdijstraat">Abdijstraat</option>
-        <option value="abtenstraat">Abtenstraat</option>
-        <option value="achturendagstraat">Achturendagstraat</option>
-        <option value="adelaarstraat">Adelaarstraat</option>
-        <option value="admiraal de Boisotstraat">
-          Admiraal de Boisotstraat
-        </option>
-        <option value="adolf Greinerstraat">Adolf Greinerstraat</option>
-        <option value="adolf Menystraat">Adolf Menystraat</option>
-        <option value="adolf Meurissestraat">Adolf Meurissestraat</option>
-        <option value="adriaan Brouwerstraat">Adriaan Brouwerstraat</option>
-        <option value="aimé De Graevestraat">Aimé De Graevestraat</option>
-      </select>
-    </vl-demo>
+        <vl-demo data-vl-title="Select van straten met een onbeperkt aantal resultaten">
+            <select id="multiselect-onbeperkt" is="vl-multiselect" data-vl-select data-vl-select-search-no-result-limit>
+                <option placeholder value="">Kies een straat</option>
+                <option value="aakstraat">Aakstraat</option>
+                <option value="aalmoezenierstraat">Aalmoezenierstraat</option>
+                <option value="aarschotstraat">Aarschotstraat</option>
+                <option value="aartselaarstraat">Aartselaarstraat</option>
+                <option value="abdijstraat">Abdijstraat</option>
+                <option value="abtenstraat">Abtenstraat</option>
+                <option value="achturendagstraat">Achturendagstraat</option>
+                <option value="adelaarstraat">Adelaarstraat</option>
+                <option value="admiraal de Boisotstraat">
+                    Admiraal de Boisotstraat
+                </option>
+                <option value="adolf Greinerstraat">Adolf Greinerstraat</option>
+                <option value="adolf Menystraat">Adolf Menystraat</option>
+                <option value="adolf Meurissestraat">Adolf Meurissestraat</option>
+                <option value="adriaan Brouwerstraat">Adriaan Brouwerstraat</option>
+                <option value="aimé De Graevestraat">Aimé De Graevestraat</option>
+            </select>
+        </vl-demo>
 
-    <vl-demo data-vl-title="Multiselect boven een datepicker">
-      <div is="vl-form-grid" data-vl-is-stacked>
-        <div is="vl-form-column" data-vl-size="12">
-          <select id="multiselect-datepicker" is="vl-multiselect">
-            <option value="Belgium">België</option>
-            <option value="Germany">Duitsland</option>
-            <option value="France">Frankrijk</option>
-          </select>
-        </div>
-        <div is="vl-form-column" data-vl-size="12">
-          <vl-datepicker id="datepicker"></vl-datepicker>
-        </div>
-      </div>
-    </vl-demo>
+        <vl-demo data-vl-title="Multiselect boven een datepicker">
+            <div is="vl-form-grid" data-vl-is-stacked>
+                <div is="vl-form-column" data-vl-size="12">
+                    <select id="multiselect-datepicker" is="vl-multiselect">
+                        <option value="Belgium">België</option>
+                        <option value="Germany">Duitsland</option>
+                        <option value="France">Frankrijk</option>
+                    </select>
+                </div>
+                <div is="vl-form-column" data-vl-size="12">
+                    <vl-datepicker id="datepicker"></vl-datepicker>
+                </div>
+            </div>
+        </vl-demo>
 
-    <vl-demo data-vl-title="Multiselect luister naar change events">
-      <select id="change-listener" is="vl-multiselect">
-        <option value="Belgium">België</option>
-        <option value="Germany">Duitsland</option>
-        <option value="France">Frankrijk</option>
-      </select>
-      <script type="text/javascript">
-        document.getElementById('change-listener').addEventListener('change', (e) => {
-          document.getElementById('change-listener').setAttribute('changed', '');
-        });
-      </script>
-    </vl-demo>
+        <vl-demo data-vl-title="Multiselect luister naar change events">
+            <select id="change-listener" is="vl-multiselect">
+                <option value="Belgium">België</option>
+                <option value="Germany">Duitsland</option>
+                <option value="France">Frankrijk</option>
+            </select>
+            <script type="text/javascript">
+                document.getElementById('change-listener').addEventListener('change', (e) => {
+                  document.getElementById('change-listener').setAttribute('changed', '');
+                });
+            </script>
+        </vl-demo>
 
-    <vl-demo data-vl-title="Multiselect enable en disable methode">
-      <select id="vl-multiselect-enable-disable-methode" is="vl-multiselect">
-        <option value="Belgium">België</option>
-        <option value="Germany">Duitsland</option>
-        <option value="France">Frankrijk</option>
-        <option value="Netherlands">Nederland</option>
-        <option value="Italy">Italië</option>
-      </select>
+        <vl-demo data-vl-title="Multiselect enable en disable methode">
+            <select id="vl-multiselect-enable-disable-methode" is="vl-multiselect">
+                <option value="Belgium">België</option>
+                <option value="Germany">Duitsland</option>
+                <option value="France">Frankrijk</option>
+                <option value="Netherlands">Nederland</option>
+                <option value="Italy">Italië</option>
+            </select>
 
-      <div is="vl-action-group" slot="actions">
-        <button id="enable" is="vl-button" onclick="document.getElementById('vl-multiselect-enable-disable-methode').enable()" type="button">
-          Enable
-        </button>
-        <button id="disable" is="vl-button" onclick="document.getElementById('vl-multiselect-enable-disable-methode').disable()" type="button">
-          Disable
-        </button>
-      </div>
-    </vl-demo>
+            <div is="vl-action-group" slot="actions">
+                <button id="enable" is="vl-button" onclick="document.getElementById('vl-multiselect-enable-disable-methode').enable()" type="button">
+                    Enable
+                </button>
+                <button id="disable" is="vl-button" onclick="document.getElementById('vl-multiselect-enable-disable-methode').disable()" type="button">
+                    Disable
+                </button>
+            </div>
+        </vl-demo>
 
-    <vl-demo data-vl-title="Multiselect zet en verwijder keuze methoden">
-      <select id="vl-multiselect-set-get-methode" is="vl-multiselect">
-        <option value="Belgium">België</option>
-        <option value="Germany">Duitsland</option>
-        <option value="France">Frankrijk</option>
-        <option value="Netherlands">Nederland</option>
-        <option value="Italy">Italië</option>
-      </select>
+        <vl-demo data-vl-title="Multiselect zet en verwijder keuze methoden">
+            <select id="vl-multiselect-set-get-methode" is="vl-multiselect">
+                <option value="Belgium">België</option>
+                <option value="Germany">Duitsland</option>
+                <option value="France">Frankrijk</option>
+                <option value="Netherlands">Nederland</option>
+                <option value="Italy">Italië</option>
+            </select>
 
-      <div is="vl-action-group" slot="actions">
-        <button id="duitsland" is="vl-button" onclick="document.getElementById('vl-multiselect-set-get-methode').value = 'Germany'" type="button">
-          Kies Duitsland
-        </button>
-        <button id="be-nl" is="vl-button" onclick="document.getElementById('vl-multiselect-set-get-methode').values = ['Belgium', 'Netherlands']" type="button">
-          Kies België en Nederland
-        </button>
-        <button id="verwijder" is="vl-button" onclick="document.getElementById('vl-multiselect-set-get-methode').removeActive()" type="button">
-          Verwijder selectie
-        </button>
-      </div>
-    </vl-demo>
+            <div is="vl-action-group" slot="actions">
+                <button id="duitsland" is="vl-button" onclick="document.getElementById('vl-multiselect-set-get-methode').value = 'Germany'" type="button">
+                    Kies Duitsland
+                </button>
+                <button id="be-nl" is="vl-button" onclick="document.getElementById('vl-multiselect-set-get-methode').values = ['Belgium', 'Netherlands']" type="button">
+                    Kies België en Nederland
+                </button>
+                <button id="verwijder" is="vl-button" onclick="document.getElementById('vl-multiselect-set-get-methode').removeActive()" type="button">
+                    Verwijder selectie
+                </button>
+            </div>
+        </vl-demo>
 
-    <vl-demo data-vl-title="Multiselect focus">
-      <select id="vl-multiselect-focus" is="vl-multiselect">
-        <option value="Belgium">België</option>
-        <option value="Germany">Duitsland</option>
-        <option value="France">Frankrijk</option>
-      </select>
-      <button is="vl-button" onclick="document.getElementById('vl-multiselect-focus').focus()" slot="actions">
-        Focus
-      </button>
-    </vl-demo>
-  </vl-demo-page>
+        <vl-demo data-vl-title="Multiselect focus">
+            <select id="vl-multiselect-focus" is="vl-multiselect">
+                <option value="Belgium">België</option>
+                <option value="Germany">Duitsland</option>
+                <option value="France">Frankrijk</option>
+            </select>
+            <button is="vl-button" onclick="document.getElementById('vl-multiselect-focus').focus()" slot="actions">
+                Focus
+            </button>
+        </vl-demo>
+    </vl-demo-page>
 </body>
 </html>

--- a/demo/vl-multiselect.html
+++ b/demo/vl-multiselect.html
@@ -198,12 +198,12 @@
         </select>
         <script type="text/javascript">
           document
-            .getElementById("change-listener")
-            .addEventListener("change", (e) => {
-              document
-                .getElementById("change-listener")
-                .setAttribute("changed", "");
-            });
+              .getElementById('change-listener')
+              .addEventListener('change', (e) => {
+                document
+                    .getElementById('change-listener')
+                    .setAttribute('changed', '');
+              });
         </script>
       </vl-demo>
 

--- a/src/vl-multiselect.js
+++ b/src/vl-multiselect.js
@@ -1,5 +1,5 @@
-import {define} from '/node_modules/vl-ui-core/dist/vl-core.js';
-import {VlSelect} from '/node_modules/vl-ui-select/dist/vl-select.js';
+import { define } from '/node_modules/vl-ui-core/dist/vl-core.js';
+import { VlSelect } from '/node_modules/vl-ui-select/dist/vl-select.js';
 
 /**
  * VlMultiSelect
@@ -24,17 +24,22 @@ export class VlMultiSelect extends VlSelect {
 
   connectedCallback() {
     this.classList.add('vl-multiselect');
-    this.setAttribute('multiple', 'multiple');
+    this.setAttribute('multiple', '');
     this.setAttribute('data-vl-multiselect', '');
-    const options = Array.from(this.querySelectorAll('option'));
 
-    const hasSelected = options.some((option) => {
-      return option.hasAttribute('selected') === true;
-    });
+    const hasSelected = this.hasSelected();
     if (!hasSelected) this.value = undefined;
 
     super.connectedCallback();
   }
+
+  hasSelected = () => {
+    const options = Array.from(this.querySelectorAll('option'));
+
+    return options.some((option) => {
+      return option.hasAttribute('selected');
+    });
+  };
 
   /**
    * Geeft de ready event naam.
@@ -85,5 +90,5 @@ export class VlMultiSelect extends VlSelect {
 }
 
 window.customElements
-    .whenDefined('vl-select')
-    .then(() => define('vl-multiselect', VlMultiSelect, {extends: 'select'}));
+  .whenDefined('vl-select')
+  .then(() => define('vl-multiselect', VlMultiSelect, { extends: 'select' }));

--- a/src/vl-multiselect.js
+++ b/src/vl-multiselect.js
@@ -24,8 +24,15 @@ export class VlMultiSelect extends VlSelect {
 
   connectedCallback() {
     this.classList.add('vl-multiselect');
+    this.setAttribute('multiple', 'multiple');
     this.setAttribute('data-vl-multiselect', '');
-    this.setAttribute('multiple', '');
+    const options = Array.from(this.querySelectorAll('option'));
+
+    const hasSelected = options.some((option) => {
+      return option.hasAttribute('selected') === true;
+    });
+    if (!hasSelected) this.value = undefined;
+
     super.connectedCallback();
   }
 

--- a/src/vl-multiselect.js
+++ b/src/vl-multiselect.js
@@ -25,6 +25,7 @@ export class VlMultiSelect extends VlSelect {
   connectedCallback() {
     this.classList.add('vl-multiselect');
     this.setAttribute('data-vl-multiselect', '');
+    this.setAttribute('multiple', '');
     super.connectedCallback();
   }
 
@@ -76,4 +77,6 @@ export class VlMultiSelect extends VlSelect {
   }
 }
 
-window.customElements.whenDefined('vl-select').then(() => define('vl-multiselect', VlMultiSelect, {extends: 'select'}));
+window.customElements
+    .whenDefined('vl-select')
+    .then(() => define('vl-multiselect', VlMultiSelect, {extends: 'select'}));

--- a/test/unit/vl-multiselect.test.html
+++ b/test/unit/vl-multiselect.test.html
@@ -1,106 +1,86 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="utf-8" />
-    <script src="../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-    <script src="../../../web-component-tester/browser.js"></script>
-    <script src="../../node_modules/sinon/pkg/sinon.js"></script>
-    <script type="module" src="../../src/vl-multiselect.js"></script>
+  
+<head>
+  <meta charset="utf-8" />
+  <script src="../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../../web-component-tester/browser.js"></script>
+  <script src="../../node_modules/sinon/pkg/sinon.js"></script>
+  <script type="module" src="../../src/vl-multiselect.js"></script>
 
-    <link rel="stylesheet" type="text/css" href="/src/style.css" />
-  </head>
+  <link rel="stylesheet" type="text/css" href="/src/style.css" />
+</head>
 
-  <body>
-    <test-fixture id="vl-multiselect-fixture">
-      <template>
-        <select id="multiselect" is="vl-multiselect"></select>
-      </template>
-    </test-fixture>
+<body>
+  <test-fixture id="vl-multiselect-fixture">
+    <template>
+      <select id="multiselect" is="vl-multiselect"></select>
+    </template>
+  </test-fixture>
 
-    <test-fixture id="vl-multiselect-fixture-success">
-      <template>
-        <select
-          id="multiselect"
-          is="vl-multiselect"
-          data-vl-success
-          data-vl-multiselect
-        ></select>
-      </template>
-    </test-fixture>
+  <test-fixture id="vl-multiselect-fixture-success">
+    <template>
+      <select id="multiselect" is="vl-multiselect" data-vl-success data-vl-multiselect
+      ></select>
+    </template>
+  </test-fixture>
 
-    <test-fixture id="vl-multiselect-fixture-error">
-      <template>
-        <select
-          id="multiselect"
-          is="vl-multiselect"
-          data-vl-error
-          data-vl-multiselect
-        ></select>
-      </template>
-    </test-fixture>
+  <test-fixture id="vl-multiselect-fixture-error">
+    <template>
+      <select id="multiselect" is="vl-multiselect" data-vl-error data-vl-multiselect></select>
+    </template>
+  </test-fixture>
 
-    <script type="module">
-      import {awaitUntil} from 'vl-ui-core/dist/vl-core';
+  <script type="module">
+    import {awaitUntil} from 'vl-ui-core/dist/vl-core';
 
-      suite('vl-multiselect', () => {
-        setup((done) => {
-          customElements.whenDefined('vl-multiselect').then(() => done());
-        });
+    suite('vl-multiselect', () => {
+      setup((done) => {
+        customElements.whenDefined('vl-multiselect').then(() => done());
+      });
 
-        test('heeft de vl-multiselect class en attributen', () => {
-          const element = fixture('vl-multiselect-fixture');
-          assert.isTrue(element.classList.contains('vl-multiselect'));
-          assert.isTrue(element.hasAttribute('data-vl-multiselect'));
-        });
+      test('heeft de vl-multiselect class en attributen', () => {
+        const element = fixture('vl-multiselect-fixture');
+        assert.isTrue(element.classList.contains('vl-multiselect'));
+        assert.isTrue(element.hasAttribute('data-vl-multiselect'));
+      });
 
-        test('wanneer het vl-multiselect element volledig klaar is zal het een ready event versturen', (done) => {
-          const element = fixture('vl-multiselect-fixture');
-          element.addEventListener(element.readyEvent, () => done());
-          element.dress();
-        });
+      test('wanneer het vl-multiselect element volledig klaar is zal het een ready event versturen', (done) => {
+        const element = fixture('vl-multiselect-fixture');
+        element.addEventListener(element.readyEvent, () => done());
+        element.dress();
+      });
 
-        test('wanneer het vl-multiselect element success of error attribuut bevat zal dit zichtbaar zijn', (done) => {
-          let element = fixture('vl-multiselect-fixture-success');
+      test('wanneer het vl-multiselect element success of error attribuut bevat zal dit zichtbaar zijn', (done) => {
+        let element = fixture('vl-multiselect-fixture-success');
+        element.addEventListener(element.readyEvent, async () => {
+          await awaitUntil(() => {
+            const container = element.parentElement.parentElement.parentElement;
+            return container.classList.contains('vl-input-field--success');
+          });
+          assert.equal(getComputedStyle(element.parentElement.parentElement)['background-color'], 'rgb(236, 246, 238)');
+
+          element = fixture('vl-multiselect-fixture-error');
           element.addEventListener(element.readyEvent, async () => {
             await awaitUntil(() => {
-              const container =
-                element.parentElement.parentElement.parentElement;
-              return container.classList.contains('vl-input-field--success');
+              const container = element.parentElement.parentElement.parentElement;
+              return container.classList.contains('vl-input-field--error');
             });
-            assert.equal(
-                getComputedStyle(element.parentElement.parentElement)[
-                    'background-color'
-                ],
-                'rgb(236, 246, 238)',
-            );
-
-            element = fixture('vl-multiselect-fixture-error');
-            element.addEventListener(element.readyEvent, async () => {
-              await awaitUntil(() => {
-                const container =
-                  element.parentElement.parentElement.parentElement;
-                return container.classList.contains('vl-input-field--error');
-              });
-              assert.equal(
-                  getComputedStyle(element.parentElement.parentElement)[
-                      'background-color'
-                  ],
-                  'rgb(251, 235, 235)',
-              );
-              done();
-            });
-          });
-        });
-
-        test('kan programmatisch focus activeren', (done) => {
-          const element = fixture('vl-multiselect-fixture');
-          element.addEventListener(element.readyEvent, async () => {
-            element._inputElement.addEventListener('focus', () => done());
-            element.focus();
+            assert.equal(getComputedStyle(element.parentElement.parentElement)['background-color'], 'rgb(251, 235, 235)');
+            done();
           });
         });
       });
-    </script>
-  </body>
+
+      test('kan programmatisch focus activeren', (done) => {
+        const element = fixture('vl-multiselect-fixture');
+        element.addEventListener(element.readyEvent, async () => {
+          element._inputElement.addEventListener('focus', () => done());
+          element.focus();
+        });
+      });
+    });
+  </script>
+</body>
 </html>
 

--- a/test/unit/vl-multiselect.test.html
+++ b/test/unit/vl-multiselect.test.html
@@ -1,85 +1,106 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
+  <head>
+    <meta charset="utf-8" />
+    <script src="../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="../../../web-component-tester/browser.js"></script>
+    <script src="../../node_modules/sinon/pkg/sinon.js"></script>
+    <script type="module" src="../../src/vl-multiselect.js"></script>
 
-<head>
-  <meta charset="utf-8">
-  <script src="../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../web-component-tester/browser.js"></script>
-  <script src="../../node_modules/sinon/pkg/sinon.js"></script>
-  <script type="module" src="../../src/vl-multiselect.js"></script>
+    <link rel="stylesheet" type="text/css" href="/src/style.css" />
+  </head>
 
-  <link rel="stylesheet" type="text/css" href="/src/style.css">
-</head>
+  <body>
+    <test-fixture id="vl-multiselect-fixture">
+      <template>
+        <select id="multiselect" is="vl-multiselect"></select>
+      </template>
+    </test-fixture>
 
-<body>
-  <test-fixture id="vl-multiselect-fixture">
-    <template>
-      <select id="multiselect" multiple is="vl-multiselect"></select>
-    </template>
-  </test-fixture>
+    <test-fixture id="vl-multiselect-fixture-success">
+      <template>
+        <select
+          id="multiselect"
+          is="vl-multiselect"
+          data-vl-success
+          data-vl-multiselect
+        ></select>
+      </template>
+    </test-fixture>
 
-  <test-fixture id="vl-multiselect-fixture-success">
-    <template>
-      <select id="multiselect" multiple is="vl-multiselect" data-vl-success data-vl-multiselect></select>
-    </template>
-  </test-fixture>
+    <test-fixture id="vl-multiselect-fixture-error">
+      <template>
+        <select
+          id="multiselect"
+          is="vl-multiselect"
+          data-vl-error
+          data-vl-multiselect
+        ></select>
+      </template>
+    </test-fixture>
 
-  <test-fixture id="vl-multiselect-fixture-error">
-    <template>
-      <select id="multiselect" multiple is="vl-multiselect" data-vl-error data-vl-multiselect></select>
-    </template>
-  </test-fixture>
+    <script type="module">
+      import { awaitUntil } from "vl-ui-core/dist/vl-core";
 
-  <script type="module">
-    import {awaitUntil} from 'vl-ui-core/dist/vl-core';
+      suite("vl-multiselect", () => {
+        setup((done) => {
+          customElements.whenDefined("vl-multiselect").then(() => done());
+        });
 
-    suite('vl-multiselect', () => {
-      setup((done) => {
-        customElements.whenDefined('vl-multiselect').then(() => done());
-      });
+        test("heeft de vl-multiselect class en attributen", () => {
+          const element = fixture("vl-multiselect-fixture");
+          assert.isTrue(element.classList.contains("vl-multiselect"));
+          assert.isTrue(element.hasAttribute("data-vl-multiselect"));
+        });
 
-      test('heeft de vl-multiselect class en attributen', () => {
-        const element = fixture('vl-multiselect-fixture');
-        assert.isTrue(element.classList.contains('vl-multiselect'));
-        assert.isTrue(element.hasAttribute('data-vl-multiselect'));
-      });
+        test("wanneer het vl-multiselect element volledig klaar is zal het een ready event versturen", (done) => {
+          const element = fixture("vl-multiselect-fixture");
+          element.addEventListener(element.readyEvent, () => done());
+          element.dress();
+        });
 
-      test('wanneer het vl-multiselect element volledig klaar is zal het een ready event versturen', (done) => {
-        const element = fixture('vl-multiselect-fixture');
-        element.addEventListener(element.readyEvent, () => done());
-        element.dress();
-      });
-
-      test('wanneer het vl-multiselect element success of error attribuut bevat zal dit zichtbaar zijn', (done) => {
-        let element = fixture('vl-multiselect-fixture-success');
-        element.addEventListener(element.readyEvent, async () => {
-          await awaitUntil(() => {
-            const container = element.parentElement.parentElement.parentElement;
-            return container.classList.contains('vl-input-field--success');
-          });
-          assert.equal(getComputedStyle(element.parentElement.parentElement)['background-color'], 'rgb(236, 246, 238)');
-
-          element = fixture('vl-multiselect-fixture-error');
+        test("wanneer het vl-multiselect element success of error attribuut bevat zal dit zichtbaar zijn", (done) => {
+          let element = fixture("vl-multiselect-fixture-success");
           element.addEventListener(element.readyEvent, async () => {
             await awaitUntil(() => {
-              const container = element.parentElement.parentElement.parentElement;
-              return container.classList.contains('vl-input-field--error');
+              const container =
+                element.parentElement.parentElement.parentElement;
+              return container.classList.contains("vl-input-field--success");
             });
-            assert.equal(getComputedStyle(element.parentElement.parentElement)['background-color'], 'rgb(251, 235, 235)');
-            done();
+            assert.equal(
+              getComputedStyle(element.parentElement.parentElement)[
+                "background-color"
+              ],
+              "rgb(236, 246, 238)"
+            );
+
+            element = fixture("vl-multiselect-fixture-error");
+            element.addEventListener(element.readyEvent, async () => {
+              await awaitUntil(() => {
+                const container =
+                  element.parentElement.parentElement.parentElement;
+                return container.classList.contains("vl-input-field--error");
+              });
+              assert.equal(
+                getComputedStyle(element.parentElement.parentElement)[
+                  "background-color"
+                ],
+                "rgb(251, 235, 235)"
+              );
+              done();
+            });
+          });
+        });
+
+        test("kan programmatisch focus activeren", (done) => {
+          const element = fixture("vl-multiselect-fixture");
+          element.addEventListener(element.readyEvent, async () => {
+            element._inputElement.addEventListener("focus", () => done());
+            element.focus();
           });
         });
       });
-
-      test('kan programmatisch focus activeren', (done) => {
-        const element = fixture('vl-multiselect-fixture');
-        element.addEventListener(element.readyEvent, async () => {
-          element._inputElement.addEventListener('focus', () => done());
-          element.focus();
-        });
-      });
-    });
-  </script>
-</body>
-
+    </script>
+  </body>
 </html>
+

--- a/test/unit/vl-multiselect.test.html
+++ b/test/unit/vl-multiselect.test.html
@@ -40,62 +40,62 @@
     </test-fixture>
 
     <script type="module">
-      import { awaitUntil } from "vl-ui-core/dist/vl-core";
+      import {awaitUntil} from 'vl-ui-core/dist/vl-core';
 
-      suite("vl-multiselect", () => {
+      suite('vl-multiselect', () => {
         setup((done) => {
-          customElements.whenDefined("vl-multiselect").then(() => done());
+          customElements.whenDefined('vl-multiselect').then(() => done());
         });
 
-        test("heeft de vl-multiselect class en attributen", () => {
-          const element = fixture("vl-multiselect-fixture");
-          assert.isTrue(element.classList.contains("vl-multiselect"));
-          assert.isTrue(element.hasAttribute("data-vl-multiselect"));
+        test('heeft de vl-multiselect class en attributen', () => {
+          const element = fixture('vl-multiselect-fixture');
+          assert.isTrue(element.classList.contains('vl-multiselect'));
+          assert.isTrue(element.hasAttribute('data-vl-multiselect'));
         });
 
-        test("wanneer het vl-multiselect element volledig klaar is zal het een ready event versturen", (done) => {
-          const element = fixture("vl-multiselect-fixture");
+        test('wanneer het vl-multiselect element volledig klaar is zal het een ready event versturen', (done) => {
+          const element = fixture('vl-multiselect-fixture');
           element.addEventListener(element.readyEvent, () => done());
           element.dress();
         });
 
-        test("wanneer het vl-multiselect element success of error attribuut bevat zal dit zichtbaar zijn", (done) => {
-          let element = fixture("vl-multiselect-fixture-success");
+        test('wanneer het vl-multiselect element success of error attribuut bevat zal dit zichtbaar zijn', (done) => {
+          let element = fixture('vl-multiselect-fixture-success');
           element.addEventListener(element.readyEvent, async () => {
             await awaitUntil(() => {
               const container =
                 element.parentElement.parentElement.parentElement;
-              return container.classList.contains("vl-input-field--success");
+              return container.classList.contains('vl-input-field--success');
             });
             assert.equal(
-              getComputedStyle(element.parentElement.parentElement)[
-                "background-color"
-              ],
-              "rgb(236, 246, 238)"
+                getComputedStyle(element.parentElement.parentElement)[
+                    'background-color'
+                ],
+                'rgb(236, 246, 238)',
             );
 
-            element = fixture("vl-multiselect-fixture-error");
+            element = fixture('vl-multiselect-fixture-error');
             element.addEventListener(element.readyEvent, async () => {
               await awaitUntil(() => {
                 const container =
                   element.parentElement.parentElement.parentElement;
-                return container.classList.contains("vl-input-field--error");
+                return container.classList.contains('vl-input-field--error');
               });
               assert.equal(
-                getComputedStyle(element.parentElement.parentElement)[
-                  "background-color"
-                ],
-                "rgb(251, 235, 235)"
+                  getComputedStyle(element.parentElement.parentElement)[
+                      'background-color'
+                  ],
+                  'rgb(251, 235, 235)',
               );
               done();
             });
           });
         });
 
-        test("kan programmatisch focus activeren", (done) => {
-          const element = fixture("vl-multiselect-fixture");
+        test('kan programmatisch focus activeren', (done) => {
+          const element = fixture('vl-multiselect-fixture');
           element.addEventListener(element.readyEvent, async () => {
-            element._inputElement.addEventListener("focus", () => done());
+            element._inputElement.addEventListener('focus', () => done());
             element.focus();
           });
         });

--- a/test/unit/vl-multiselect.test.html
+++ b/test/unit/vl-multiselect.test.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-  
+
 <head>
   <meta charset="utf-8" />
   <script src="../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
@@ -20,8 +20,7 @@
 
   <test-fixture id="vl-multiselect-fixture-success">
     <template>
-      <select id="multiselect" is="vl-multiselect" data-vl-success data-vl-multiselect
-      ></select>
+      <select id="multiselect" is="vl-multiselect" data-vl-success data-vl-multiselect></select>
     </template>
   </test-fixture>
 
@@ -82,5 +81,6 @@
     });
   </script>
 </body>
+
 </html>
 


### PR DESCRIPTION
Mijn editor zorgt voor automatische JS code formatting. Dus het lijkt erger dan het is, maar het maakt de code in my opinion wel een pak leesbaarder. 